### PR TITLE
Jeolsem

### DIFF
--- a/Analyze/Microscope Measurement Tools/Choose_Microscope_Calibration.py
+++ b/Analyze/Microscope Measurement Tools/Choose_Microscope_Calibration.py
@@ -9,11 +9,9 @@ User can optionally apply the scaling to all open images, and/or run the "Scale 
 Based off Microscope_Scale.java & Correct_3d_drift.py
 
 
-v1.2
-Demis D. John, Praevium Research Inc., 2015-05-29
+v1.3
+Demis D. John, Univ. of California Santa Barbara, 2019-02-27
 '''
-
-#print "hello outside!"
 
 ## Import some modules:
 from ij import IJ, ImagePlus, WindowManager
@@ -41,6 +39,7 @@ except ValueError:
 # microscope settings should be in the file `Microscope_Calibrations_user_settings.py`:
 import Microscope_Calibrations_user_settings as cal      # imports `names`, `cals`, `units` under namespace `cal.names` etc.
 
+mc_DEBUG = True     # Send debugging info to the log file?
 
 
 
@@ -56,19 +55,37 @@ def run():
     
     
     imp = IJ.getImage()     # get the current Image as ImagePlus object?
-    #print "imp=", imp
+    ImagePath = imp.getOriginalFileInfo().directory + os.path.sep + imp.getOriginalFileInfo().fileName
+    if mc_DEBUG: 
+        print "imp=", imp
+        print "ImagePath=", ImagePath
+    
         
     
     CalIdx, SetGlobalScale, AddScaleBar = uScopeCalDialog(cal)    # show Calibrations dialog
     
     if CalIdx == None: return       # User cancelled - exit
     
+    newcal = imp.getCalibration().copy()   # make a copy of current calibration object
+    
+    if CalIdx == 0: 
+        # For JEOL SEM - auto from accompanying *.txt
+        newPixelWidth, newUnit = getJEOLSEMCal( ImagePath )
+        newPixelHeight = newPixelWidth * 1.0
+        if mc_DEBUG: print "newPixelWidth, newUnit = ", newPixelWidth, newUnit
+    else:
+        newUnit = cal.units[CalIdx]
+        newPixelWidth = 1./cal.cals[CalIdx]  
+        newPixelHeight = newcal.pixelWidth * cal.aspect_ratio[CalIdx]
+        print "Chosen Cal=", cal.cals[CalIdx], " px/unit"
+        
+    #end if CalIdx
+
     # the following translated from "Microscope_Scale.java":
-    newcal = imp.getCalibration().copy()   # make a copy of calibration object
-    newcal.setUnit(  cal.units[CalIdx]  )
-    print "Chosen Cal=", cal.cals[CalIdx], " px/unit"
-    newcal.pixelWidth =  1./cal.cals[CalIdx]  
-    newcal.pixelHeight = newcal.pixelWidth * cal.aspect_ratio[CalIdx]
+    newcal.setUnit(  newUnit  )
+    newcal.pixelWidth =  newPixelWidth
+    newcal.pixelHeight = newPixelHeight    
+    
     
     if SetGlobalScale:
         '''Apply to all images'''
@@ -122,14 +139,19 @@ def uScopeCalDialog(cal):
     # generate text to display in list:
     # Radio Buttons:
     CalStr = []
+    
+    # add option for JEOL SEM  (CalIdx = 0)
+    CalStr.append( "JEOL SEM - auto cal from .txt")
+    
     for ii, name in enumerate(cal.names):
         CalStr.append(  name + "      (%s"%cal.cals[ii] + " pixels/%s)"%cal.units[ii]  )
+
     
     '''if > 20 cals, use dropdown list, otherwise use radio buttons'''
     if len(cal.names) > 20:
         Radio=False
         # Drop-Down list:
-        gd.addChoice("     Calibration:", CalStr, CalStr[0]   )   # default = 1st
+        gd.addChoice("     Calibration:", CalStr, CalStr[0]   )   # default = 1st (#0)
     
     else:
         Radio=True
@@ -166,6 +188,63 @@ def uScopeCalDialog(cal):
 #end uScopeCalDialog()
 
 
+def getJEOLSEMCal( filepath ):
+    '''Find accompying *.txt file that contains pixel-to-unitlength info, and apply the scale automatically.
+    Designed against a JEOL 7600F SEM.  Expects the *.xtx files to be next to the accompying image files of same name.'''
+    import re   # RegEx matching
+       
+    
+    txtpath = os.path.splitext( filepath )[0] + ".txt"
+    if mc_DEBUG: print "txtpath = ", txtpath
+    if not os.path.isfile(txtpath): raise IOError("Text File not found at: \n\t" + txtpath)
+    
+    # set up regex matching:
+    re_bar = re.compile( r'\$\$SM_MICRON_BAR (\d*)'  ) # groups the digits in "$$SM_MICRON_BAR 90"
+    re_barmark = re.compile( r'\$\$SM_MICRON_MARKER (\d*)([a-zA-Z]*)')  # groups the decimals and units in "$$SM_MICRON_MARKER 100nm"
+    
+    
+    # try to load the .txt file:
+    BarLength_px = None
+    BarLength_dist = None
+    BarLength_unit = None
+    
+    txtfile = open(txtpath, 'r')
+    try:
+        while True:
+            txtline = txtfile.readline()
+            if len(txtline) == 0:
+                # end of file, exit the loop
+                break
+            #end(if end-of-file)
+            
+            # search for strings/values:
+            match1 = re_bar.search( txtline )
+            if match1:
+                BarLength_px = float( match1.group(1)  )  # this is pixel width of the scale bar
+                if mc_DEBUG: print 'Scale Bar Pixel Length found:', match1.groups(), ' --> ', BarLength_px    
+            #end if(match1)
+            
+            match2 = re_barmark.search( txtline )
+            if match2:
+                BarLength_dist = float( match2.group(1)  )  # this is physical width of the scale bar
+                BarLength_unit = str( match2.group(2)  )
+                if mc_DEBUG: print 'Scale Bar Distance Length found:', match2.groups(), ' --> ', BarLength_dist, BarLength_unit
+            #end if(match2)
+            
+        #end while(file-reading)
+
+    except IOError:
+        raise IOError("Could not load text file that accompanies this image file.  Expected the text file to have the same filename as the image, except with '.txt' extension.  Expected file to be here:\n\t" + txtpath )
+    
+    finally:
+        # make sure python closes the file no matter what
+        txtfile.close()
+    #end try(txtfile)
+    
+    # return pixel-per-unit & units
+    #return (BarLength_px/BarLength_dist), BarLength_unit
+    return (BarLength_px/BarLength_dist), BarLength_unit
+#end getJEOLSEMCal()
 
 
 run()       # Run the script function!

--- a/Analyze/Microscope Measurement Tools/Choose_Microscope_Calibration.py
+++ b/Analyze/Microscope Measurement Tools/Choose_Microscope_Calibration.py
@@ -47,18 +47,14 @@ mc_DEBUG = True     # Send debugging info to the log file?
 def run():
     '''This is the main function run when the plugin is called.'''
     
-    #print "hello in run()"
-    
-
-    
     #print cal.names, cal.cals, cal.units
     
     
-    imp = IJ.getImage()     # get the current Image as ImagePlus object?
+    imp = IJ.getImage()     # get the current Image as ImagePlus object
     ImagePath = imp.getOriginalFileInfo().directory + os.path.sep + imp.getOriginalFileInfo().fileName
     if mc_DEBUG: 
-        print "imp=", imp
-        print "ImagePath=", ImagePath
+        print("imp=", imp)
+        print("ImagePath=", ImagePath)
     
         
     
@@ -70,7 +66,8 @@ def run():
     
     if CalIdx == 0: 
         # For JEOL SEM - auto from accompanying *.txt
-        newPixelWidth, newUnit = getJEOLSEMCal( ImagePath )
+        newPixelPerUnit, newUnit = getJEOLSEMCal( ImagePath )
+        newPixelWidth = 1. / newPixelPerUnit
         newPixelHeight = newPixelWidth * 1.0
         if mc_DEBUG: print "newPixelWidth, newUnit = ", newPixelWidth, newUnit
     else:
@@ -119,15 +116,18 @@ def uScopeCalDialog(cal):
     as set in the "user_settings.py" file.
     
     `CalIdx` is the list index to the chosen calibration.  
-    Eg., if the options were 
-        ['5x', '10x', '20x']
-    and the user chose '10x', then 
-        CalIdx = 1
-    `SetGlobalScale` is a boolean from a checkbox option, if the user wants this calibration set 'globally'.
-    `AddScaleBar` is also a boolean, for a checkbox option, if user would like to run "Scale Bar..." afterwards.
+        Eg., if the options were 
+            ['5x', '10x', '20x']
+        and the user chose '10x', then 
+            CalIdx = 1
+        Returns `None` if the user cancelled the dialog.
+    
+    `SetGlobalScale` is a boolean (True/False) from a checkbox option, if the user wants this calibration set 'globally' to all open images.
+    
+    `AddScaleBar` is also a boolean (True/False), for a checkbox option, if user would like to run "Scale Bar..." afterwards.
     '''
     
-    # The following copied from Correct_3D_drift.py:
+    # The following inspired heavily by Correct_3D_drift.py:
     
     #print "uScopeCalDialog():"
     #print cal.names, [str(x) for x in cal.cals]
@@ -242,7 +242,6 @@ def getJEOLSEMCal( filepath ):
     #end try(txtfile)
     
     # return pixel-per-unit & units
-    #return (BarLength_px/BarLength_dist), BarLength_unit
     return (BarLength_px/BarLength_dist), BarLength_unit
 #end getJEOLSEMCal()
 

--- a/Analyze/Microscope Measurement Tools/Draw_Measurement_-_Line.py
+++ b/Analyze/Microscope Measurement Tools/Draw_Measurement_-_Line.py
@@ -24,14 +24,14 @@ import sys, os
 libpth = os.path.split(  os.path.split( sys.path[0] )[0]  )[0]  # split-off the "/jars/lib" part
 #print  libpth
 libpth = os.path.join(libpth, 'plugins', 'Scripts', 'Analyze', 'Microscope Measurement Tools')
-# hard-coded path, underneath the Fiji directory.
+# hard-coded path, within the Fiji directory.
 
 try:
     sys.path.index( libpth )    # see if search-path is already added
 except ValueError:
     # path wasn't included yet, so add it:
     sys.path.append( libpth )
-#sys.path.append('/Applications/Fiji.app/plugins/Scripts/Plugins/uScopeMeas/')
+#sys.path.append('/Applications/Fiji.app/plugins/Scripts/Analyze/Microscope Measurement Tools/')
 #print sys.path
 
 # microscope settings should be in the file `Microscope_Calibrations_user_settings.py`:
@@ -39,7 +39,7 @@ import Microscope_Calibrations_user_settings as sets      # imports settings und
 
 #print os.path.abspath(sets.__file__)
 #print dir(sets)
-#print sets.cals
+#print sets.cals    # see what calibrations have been set
 
 
 # the run() function is called at the end of this script:
@@ -54,9 +54,7 @@ def run():
     #print dir(imp)
     
     roi = imp.getRoi()  # get the drawn ROI
-    #print "roi=", roi
-    
-    #print roi.getClass()
+    #print "roi=", roi, roi.getClass()
     
     
     # check ROI type
@@ -78,12 +76,12 @@ def run():
     
     p1 = [  int(roi.x1d),  int(roi.y1d)  ]    # point 1 (x,y)
     p2 = [  int(roi.x2d),  int(roi.y2d)  ]    # point 2
-    print "Line Points: p1=", p1, " & p2=", p2
+    print "DrawMeas(): Line Points: p1=", p1, " & p2=", p2
     pm = midpoint(p1, p2)   # get midpoint coord
     
     
     # set ROI params from settings:
-    ''' Using new method - used ip.drawLine instead of roi.draw, since roi.draw didn't always apply the line thickness.  Would be best to use teh ROI method, in case other types of ROI's could be annotated.
+    ''' Using new method - used ip.drawLine instead of roi.draw, since roi.draw didn't always apply the line thickness.  Would be best to use the ROI method, in case other types of ROI's could be annotated.
     
     roi.setStrokeWidth( sets.linethickness )
     roi.setStrokeColor(  jColor(float(sets.linecolor[0]), float(sets.linecolor[1]), float(sets.linecolor[2]), float(sets.linecolor[3]))  )
@@ -96,10 +94,8 @@ def run():
     ip.setColor(  jColor(float(sets.linecolor[0]), float(sets.linecolor[1]), float(sets.linecolor[2]), float(sets.linecolor[3]))  )
     
     #ip.draw(roi)   # changed to ip.drawLine()
-    
     ip.drawLine( int(roi.x1d),  int(roi.y1d), int(roi.x2d),  int(roi.y2d)  )
 
-    #imp.updateAndDraw()     #update the image
     
     
     
@@ -111,10 +107,10 @@ def run():
     
     # format of measurement text (eg. 3 decimal points):
     lenstr = "%0.3f" % roi.getLength() + " %s" % (unit)  # string to print as length
-    print "Line length= %s" % lenstr
+    print "DrawMeas(): Line length= %s" % lenstr
     #print "x,y=", p2[0], p2[1]
     
-    '''determine position of text from coords'''
+    '''determine position of text from line coords, eg "bottom right" or "top left" etc.   '''
     # y-coord:
     if p2[1] > p1[1]:
         posstr = 'bottom'
@@ -183,12 +179,12 @@ def drawText( text, x, y, position='bottom right' ):
     
     position : { 'bottom right', 'top right', 'top left', 'bottom left' }, case-insensitive, optional
         Where to draw the text, with respect to the coordinates given.
-        Synonyms for 'bottom right' are 'br'.
+        Synonyms for 'bottom right' are 'br'.  This is the default.
         Synonyms for 'top right' are 'tr'.
         Synonyms for 'bottom left' are 'bl'.
         Synonyms for 'top left' are 'tl'.
     '''
-    print "drawText(): initial (x,y)=(%i,%i)"%( x, y )
+    print "drawText(): original (x,y)=(%i,%i)"%( x, y )
     
     
     # microscope settings should be in the file `Microscope_Calibrations_user_settings.py`:
@@ -212,12 +208,12 @@ def drawText( text, x, y, position='bottom right' ):
         raise ValueError( 'drawText(): Invalid `position` argument: "%s".'%(position) )
     
     
+    
+    
     '''Setup text annotation'''
-        
     # set font:
     ip.setFont(   jFont('SansSerif', 0, sets.textsize)   )
     ip.setColor(    jColor(  float(sets.textcolor[0]), float(sets.textcolor[1]), float(sets.textcolor[2]), float(sets.textcolor[3])  )   )
-    
     
     
     
@@ -239,7 +235,7 @@ def drawText( text, x, y, position='bottom right' ):
     
     
     # set coords (x,y) based on `position` argument
-    ''' By default, text is horizontally centered at point (x), and vertically above the point (y).'''
+    ''' By default, text is horizontally centered at point (x), and vertically above the point (y).  We then modify these default coords.  '''
 
     if pos[0] == 'b':
         y = y + spacer + strh   # moves down 

--- a/Analyze/Microscope Measurement Tools/MScopeCals - custom function example/JEOL_SEM_AutoCal.py
+++ b/Analyze/Microscope Measurement Tools/MScopeCals - custom function example/JEOL_SEM_AutoCal.py
@@ -1,0 +1,172 @@
+'''
+	FIJI Plugin
+Additional Function for Choose_Microscope_Calibration.py
+Demis D. John, Univ. of California Santa Barbara, 2019
+
+This file adds functions for JEOL SEM images files, to automatically load the scale calbration from the accompanying *.txt file.
+Find accompying *.txt file with same name/locaiton as the image file, parse out the pixel-to-unitlength info, and apply the scale automatically.
+Designed against a JEOL 7600F SEM with the followig TXT file version info:
+$CM_FORMAT      JEOL-SEM
+$CM_VERSION     1.0
+
+The class will be accessed by  `Choose_Microscope_Calibration.py`.
+The class must have methods named as follows:
+    MyClass() - class constructor, which defines MyClass.name attribute:
+    MyClass.name - a string that shows up in the available calibrations list.
+    MyClass.cal() - returns the Pixel-Per-Unit calibration (numeric)
+    MyClass.unit - a string that is the measurement unit, eg. "cm" or "nm" etc.
+    MyClass.aspect - numeric value of pixel aspect ratio, eg. 1.0
+
+After you edit this file, be sure to delete the corresponding *.pyclass file and restart Fiji for the changes to take effect.
+'''
+
+
+"""
+################################
+   JEOL SEM AutoCal from *.txt
+################################
+
+
+"""
+
+jeol_DEBUG = False     # Send debugging info to the log file?
+
+
+class JEOL_SEM_CalFromTxt(object):
+    '''    Class with functions for automatic calibration of image scale.
+    
+    JEOL_SEM_CalFromTxt() : (Constructor)
+        Only sets the `name` to be used in the Calibrations list.
+    
+    JEOL_SEM_CalFromTxt.name : string
+        The name that shows up in the Calibrations list.
+    
+    JEOL_SEM_CalFromTxt.cal(  ImagePlus_Object ) :
+        Takes in the ImagePlusObject being analyzed.
+        Returns the pixel-per-unit numeric value, using a custom function.
+        Sets the following internal attributes:
+            self.pixel_per_unit (unused)
+            self.unit
+            self.aspect_ratio
+    
+    JEOL_SEM_CalFromTxt.unit : string
+        String indicating the unit used in the pixel-per-unit returned by `self.cal()`.  The string will be used by annotations and set internally in ImageJ's "Set Scale" etc.  Should be the short abbreviation of the unit name.
+        Examples: "mm", "cm", "um" (will be converted to greek `mu` by ImageJ)
+    
+    JEOL_SEM_CalFromTxt.aspect_ratio
+        Numeric aspect ratio (width/height) of the pixel-per-unit, typically 1.0.
+    
+    '''
+    
+    def __init__(self):
+        ''' See `help(JEOL_SEM_CalFromTxt)` for help on this constructor.'''
+        self.name =     "JEOL SEM: AutoCal from *.txt"
+    #end __init__()
+    
+
+    def cal( self, imp ):
+        '''
+        Takes in the ImagePlusObject being analyzed.
+        Returns the pixel-per-unit numeric value.
+        For JEOL SEM image files, this is done by locating the accompying *.txt text-file and parsign it to find the image scale values.
+        Sets the following internal attributes:
+            self.unit
+            self.aspect_ratio
+        '''
+        
+        import re   # RegEx matching, for parsing text file
+        import os.path  # file-path manipulation functions
+        
+        filepath =    imp.getOriginalFileInfo().directory  +  os.path.sep  +  imp.getOriginalFileInfo().fileName
+        if jeol_DEBUG: 
+            print( "imp=", imp )
+            print( "ImagePath=", filepath )
+        
+        txtpath = os.path.splitext( filepath )[0] + ".txt"
+        if jeol_DEBUG: print "txtpath = ", txtpath
+        if not os.path.isfile(txtpath): raise IOError("Text File not found at: \n\t" + txtpath)
+        
+        # set up regex search groups:
+        re_bar = re.compile( r'\$\$SM_MICRON_BAR (\d*)'  ) # captures the digits in "$$SM_MICRON_BAR 90" to a group
+        re_barmark = re.compile( r'\$\$SM_MICRON_MARKER (\d*)([a-zA-Z]*)')  # captures the decimals and units in "$$SM_MICRON_MARKER 100nm" to separate groups
+    
+    
+        # try to load the .txt file:
+        BarLength_px = None
+        BarLength_dist = None
+        BarLength_unit = None
+    
+        txtfile = open(txtpath, 'r')
+        try:
+            while True:
+                txtline = txtfile.readline()  # grab one line of text
+                if len(txtline) == 0:
+                    # end of file, exit the loop
+                    break
+                #end(if end-of-file)
+            
+            
+                # search for strings/values:
+                match1 = re_bar.search( txtline )
+                if match1:
+                    BarLength_px = float( match1.group(1)  )  # this is pixel width of the scale bar
+                    if jeol_DEBUG: print 'Scale Bar Pixel Length found:', match1.groups(), ' --> ', BarLength_px    
+                #end if(match1)
+            
+            
+                match2 = re_barmark.search( txtline )
+                if match2:
+                    BarLength_dist = float( match2.group(1)  )  # this is physical width of the scale bar
+                    BarLength_unit = str( match2.group(2)  )
+                    if jeol_DEBUG: print 'Scale Bar Distance Length found:', match2.groups(), ' --> ', BarLength_dist, BarLength_unit
+                #end if(match2)
+            
+            #end while(file-reading)
+
+        except IOError:
+            raise IOError("Could not load text file that accompanies this image file.  Expected the text file to have the same filename as the image, except with '.txt' extension.  Expected file to be here:\n\t" + txtpath )
+    
+        finally:
+            # make sure python closes the file no matter what
+            txtfile.close()
+        #end try(txtfile)
+        
+        self.pixel_per_unit = (BarLength_px/BarLength_dist)
+        self.unit = BarLength_unit
+        self.aspect_ratio = 1.0
+        
+        # return pixel-per-unit
+        return self.pixel_per_unit
+    #end cal()
+#end class(JEOL_SEM_CalFromTxt)
+
+
+
+
+
+
+
+
+
+
+
+
+'''
+---------------------------------------------------------
+Warn user if they run this file as a stand-alone plugin.
+'''
+
+def run():
+    ''' If someone tries to run this file by itself, warn them of their error.  Unfortunately, since I was too lazy to make Microscope_Calibrations a full plugin (rather than a script), this accompanying settings file will show up in the Scripts menu.'''
+    from ij.gui import GenericDialog
+    
+    gd = GenericDialog("Microscope_Calibrations_user_settings.py")
+    gd.addMessage("This file is only for adding functionality to the plugin 'Microscope Measurement Tools'.\nNothing is done when this settings file is run by itself."  )
+    
+    gd.showDialog()
+#end run()
+
+if __name__ == '__main__':
+    run()   # run the above function if the user called this file!
+
+

--- a/Analyze/Microscope Measurement Tools/MScopeCals - custom function example/Microscope_Calibrations_user_settings.py
+++ b/Analyze/Microscope Measurement Tools/MScopeCals - custom function example/Microscope_Calibrations_user_settings.py
@@ -1,0 +1,141 @@
+'''
+	FIJI Plugin
+Configuration for Microscope Calibrations
+Demis D. John, Univ. of California Santa Barbara, 2019
+
+This version of the settings file contains a pointer to a custom function, which automatically sets the scale by loading a text file that corresponds to the loaded image file.  The custom function is found in a separate file "JEOL_SEM_AutoCal.py", and you can see the class defined in this file being loaded below.
+In addition, an instance of the class is inserted into the lists of names/calibrations, and all information will be obtained from the Class/external file.
+
+Please make sure the lists `names`, `cals` and `units` all have the same number of items!
+
+After you edit this file, be sure to delete the corresponding *.pyclass file and restart Fiji for the settings to take effect.
+'''
+
+
+"""
+################################
+   Microscope Image settings
+################################
+
+Microscope scaling/pixel-size calibration settings.
+"""
+
+# The names of the microscope calibrations (shows up as the radio button names):
+#   For custom functions, pass the handle to an instantiated class instead of a string.
+
+# Custom Function: Load JEOL SEM autocal class from a file:
+from JEOL_SEM_AutoCal   import JEOL_SEM_CalFromTxt
+jeol_sem_cal_from_txt = JEOL_SEM_CalFromTxt()    # instantiate the class
+
+
+names = [
+        'FluoroScope 5x', 
+        'FluoroScope 20x', 
+        'FluoroScope 50x', 
+        'FluoroScope 100x', 
+        'FluoroScope 150x',
+        'Olympus DUV 100x',
+        jeol_sem_cal_from_txt,   # instance of class with custom function `MyClass.cal()` for setting image scale.
+        ]
+
+
+# The 'pixel-per-unit' obtained from the "Set Scale..." Dialog, for each named calibration above:
+cals = [
+        0.9058,
+        1.81,  
+        4.525,  
+        9.0667,  
+        13.5333,
+        54.6875,
+        jeol_sem_cal_from_txt,  # placeholder for custom function
+        ]
+#   This is just 1/pixel_width, in case you were wondering.
+
+
+# length-units for each calibration:
+units = [
+        'um',
+        'um',
+        'um',
+        'um',
+        'um',
+        'um',
+        jeol_sem_cal_from_txt,
+        ]
+# for identical units for all cals, use the following line instead (uncomment):
+#units = ['um'    for x in cals]    # list-comprehension with constant `um`
+
+
+# Aspect Ratio for each calibration (default should be 1.0 )
+#   Ratio is defined as so: pixelHeight = pixelWidth * AspectRatio
+# Uncomment the following line to use custom aspect ratios:
+aspect_ratio = [
+        1, 
+        1, 
+        1, 
+        1, 
+        1,
+        1,
+        jeol_sem_cal_from_txt,
+                ]
+# The following sets the aspect ratio to 1 for all calibrations (uncomment to use):
+#aspect_ratio =  [ 1.0    for x in cals ]   # list-comprehension with constant `1`
+
+
+
+
+
+"""
+################################
+       Draw Line settings
+################################
+
+Settings for the script "Draw Measurement - Line
+
+Colors are specified as:
+    [R, G, B, transparency] values, from 0->1.0.  
+    Leave last value as 1 for completely opaque.  
+    Eg. opaque red would be [1,0,0, 1]
+    and half-transparent blue would be [0,0,1, 0.5]
+    opaque black is [0,0,0, 1]
+    opaque white is [1,1,1, 1]
+"""
+
+linethickness = 5.0     # in pixels
+linecolor = [ 0, 0.7, 0,   1.0]     
+textsize = 30           # text height in pixels, I think
+textcolor =     [ 0, 0.8, 0,   1.0]
+textbackgroundcolor = [ 0, 0, 0,   0.6]       # background color behind text.
+#textbackgroundcolor = None      # set to None for no background - uncomment this line
+texttoleft = True      # put text on left or right side of last point?
+
+
+
+
+
+
+
+
+
+
+'''
+---------------------------------------------------------
+Warn user if they run this file as a stand-alone plugin.
+'''
+
+def run():
+    ''' If someone tries to run this file by itself, warn them of their error.  Unfortunately, since I was too lazy to make Microscope_Calibrations a full plugin (rather than a script), this accompanying settings file will show up in the Scripts menu.'''
+    from ij.gui import GenericDialog
+    
+    gd = GenericDialog("Microscope_Calibrations_user_settings.py")
+    gd.addMessage("This file is only for setting the microscope calibrations and settings for the plugins 'Microscope Measurement Tools'.\nNothing is done when this settings file is run by itself.\nPlease open this file in a text editor instead, to edit the calibrations.\n  \n"  +  \
+    "The file should reside in a path like the following\n"  +  \
+    "Fiji.app/plugins/Scripts/Analyze/Microscope Measurement Tools/Microscope_Calibrations_user_settings.py\n  "  +  "\n" +  \
+    "Changes to the settings file are not automatically picked up by Fiji.  The workaround is to\n  1) Quit Fiji.\n  2) Delete the '$py.class' file 'Microscope_Calibrations_user_settings$py.class'\n  3) Open Fiji.  Make sure the new settings show up in 'Choose Microscope Calibration'."  )
+    
+    gd.showDialog()
+#end run()
+
+if __name__ == '__main__':
+    run()   # run the above function if the user called this file!
+

--- a/Analyze/Microscope Measurement Tools/Microscope_Calibrations_user_settings.py
+++ b/Analyze/Microscope Measurement Tools/Microscope_Calibrations_user_settings.py
@@ -24,6 +24,7 @@ names = [
         'FluoroScope 50x', 
         'FluoroScope 100x', 
         'FluoroScope 150x',
+        'Olympus DUV 100x',
         ]
 
 
@@ -34,6 +35,7 @@ cals = [
         4.525,  
         9.0667,  
         13.5333,
+        54.6875,
         ]
 #   This is just 1/pixel_width, in case you were wondering.
 


### PR DESCRIPTION
New ability to add a custom function to the list of calibrations to use.  Example included (but not in use by default).  Useful when calibration info is found in an accompanying text file or can otherwise be determined automatically, but is too annoying to hard-code. (For example, the many different magnifications of an SEM machine - impractical to hard-code the magnifications of each).