### PR TITLE
Fix broken list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ The "Draw Measurement" plugin then allows you to draw a line with the calibrated
 1. Open FIJI
 1. Open an image file taken at the desired maginification with a measurment marker. e.g. Open a photo of your micrometer slide taken with your 40x objective
 1. Zoom in on the photo to view the micrometer scale
-1. Draw a line `ROI` (Region Of Interest) along the calibration measurment feature. e.g. along the micrometer
-<img src="https://github.com/Elaniobro/Microscope-Measurement-Tools/blob/master/img/roi.png?raw=true" width="600"/>
+1. Draw a line `ROI` (Region Of Interest) along the calibration measurment feature. e.g. along the micrometer <img src="https://github.com/Elaniobro/Microscope-Measurement-Tools/blob/master/img/roi.png?raw=true" width="600"/>
 1. Navigate to and select `Analyze > Set Scale`
 1. The "Distance in Pixels" will already be set by your line ROI
-1. Type in the "Known Distance" from your measurement feature, mine is 5μm
-<img src="https://github.com/Elaniobro/Microscope-Measurement-Tools/blob/master/img/set_scale.png?raw=true" width="600"/>
+1. Type in the "Known Distance" from your measurement feature, mine is 5μm <img src="https://github.com/Elaniobro/Microscope-Measurement-Tools/blob/master/img/set_scale.png?raw=true" width="600"/>
 1. Record the resulting "Scale" value, e.g. 31.1716 pixel/unit, where unit is cm, mm, μm, etc
 1. The "Scale" value will be used in your `Microscope_Calibrations_user_settings.py` file, so recored both a name and the scale value. e.g:
     ```
@@ -67,9 +65,8 @@ The "Draw Measurement" plugin then allows you to draw a line with the calibrated
 1. Re-start the FIJI application. This will allow the application to register the changes you made to the plugin
 **note** _for any subsquent changes, you will have to save the file, quit the application and re-open it to see the changes_
 1. Open an image
-1. Run `Analyze > Microscope Measurment Tools > Choose Microscope Calibration` and see a pop-up window that shows the new names and calibration values you set in `Microscope_Calibrations_user_settings.py`.
-<img src="https://raw.githubusercontent.com/Elaniobro/Microscope-Measurement-Tools/master/img/microscope_calibrations.png" width="600"/>
-1. You may also apply the same scale and scale bar to all images you have open, but selecting the checkboxes. Doing so will open another pop-up, where you can see how the scale will look. In the example below, the bar is set to 10μm, white text and placed in the lower right corner
+1. Run `Analyze > Microscope Measurment Tools > Choose Microscope Calibration` and see a pop-up window that shows the new names and calibration values you set in `Microscope_Calibrations_user_settings.py`. <img src="https://raw.githubusercontent.com/Elaniobro/Microscope-Measurement-Tools/master/img/microscope_calibrations.png" width="600"/>
+1. You may also apply the same scale and scale bar to all images you have open, but selecting the checkboxes. Doing so will open another pop-up, where you can see how the scale will look. In the example below, the bar is set to 10μm, white text and placed in the lower right corner 
 <img src="https://raw.githubusercontent.com/Elaniobro/Microscope-Measurement-Tools/master/img/scale_bar.png" width="600"/>
 
 ## 📈 Usage

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ The "Draw Measurement" plugin then allows you to draw a line with the calibrated
     1. Move the folder into the FIJI plugins directory on your MacOS
     <img src="https://github.com/Elaniobro/Microscope-Measurement-Tools/blob/master/img/pkg_contents.png?raw=true" width="600"/>
 
-
+**note** _MacOS may prevent you from opening an unverified application follow steps below to open_
+* In System Preferences, click `Security & Privacy > General`, then click the Lock button to allow you to make changes to your settings. You will need to provide your password, or use Touch ID, to unlock this.
+* The last app you attempted to open will be listed underneath your App Store security options. To launch the app (or rather, the DMG image file containing your app), click Open Anyway.
+* Once installed, if you have not previously opened the app, macOS will warn you that you are attempting to open an app from the internet. You’ll need to approve it for launch, so click the Open button to do this
 
 ## ⚖️ Calibration
 1. Take photos of a known measurment sample with your microscope, at each magnification you want to calibrate

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The "Draw Measurement" plugin then allows you to draw a line with the calibrated
 1. The "Distance in Pixels" will already be set by your line ROI
 1. Type in the "Known Distance" from your measurement feature, mine is 5μm
 <img src="https://github.com/Elaniobro/Microscope-Measurement-Tools/blob/master/img/set_scale.png?raw=true" width="600"/>
-1. Record the resulting "Scale" value, e.g. 31.1716 pixel/unit, where unit is cm, mm, μm, etc..
+1. Record the resulting "Scale" value, e.g. 31.1716 pixel/unit, where unit is cm, mm, μm, etc
 1. The "Scale" value will be used in your `Microscope_Calibrations_user_settings.py` file, so recored both a name and the scale value. e.g:
     ```
     Swift 350T 4x: 0.9058 px/μm


### PR DESCRIPTION
### Description: ✍️
* `<img/>` tags need to be a part of a list item or it breaks the list. I did not catch this until viewing it in github. My markdown preview tool showed the list intact.
* Add info for those macOS users who get the unverified app install

### Visual: 🔍
#### Before:
<img width="888" alt="Screen Shot 2021-06-13 at 15 16 29" src="https://user-images.githubusercontent.com/710847/121819356-9262bf00-cc5a-11eb-8907-a6f69f816a1f.png">

#### After:
<img width="732" alt="Screen Shot 2021-06-13 at 15 16 18" src="https://user-images.githubusercontent.com/710847/121819358-968edc80-cc5a-11eb-881d-d441677dbcfd.png">
